### PR TITLE
Fix travis, R, sklearn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,13 @@ sudo: true
 os:
 - linux
 dist:
-# take the latest supported LTS version
-- trusty
+# take the latest supported version
+- xenial
 
 # install dependencies
 
 before_install:
-# install latest r
-- sudo sh -c 'echo "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list'
-- gpg --keyserver keyserver.ubuntu.com --recv-key E084DAB9
-- gpg -a --export E084DAB9 | sudo apt-key add -
+# install r
 - sudo apt-get update
 - sudo apt-get install r-base r-base-dev r-base-core r-recommended
 # from apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ dist:
 # install dependencies
 
 before_install:
-# install r
+# install latest r
+- sudo sh -c 'echo "deb http://cran.rstudio.com/bin/linux/ubuntu/xenial/" >> /etc/apt/sources.list'
+- gpg --keyserver keyserver.ubuntu.com --recv-key E084DAB9
+- gpg -a --export E084DAB9 | sudo apt-key add -
 - sudo apt-get update
 - sudo apt-get install r-base r-base-dev r-base-core r-recommended
 # from apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ dist:
 before_install:
 # install latest r
 - sudo sh -c 'echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial/" >> /etc/apt/sources.list'
+- gpg --keyserver keyserver.ubuntu.com --recv-key E084DAB9
+- gpg -a --export E084DAB9 | sudo apt-key add -
 - sudo apt-get update
 - sudo apt-get install r-base r-base-dev r-base-core r-recommended
 # from apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ dist:
 
 before_install:
 # install latest r
-- sudo sh -c 'echo "deb http://cran.rstudio.com/bin/linux/ubuntu/xenial/" >> /etc/apt/sources.list'
+- sudo sh -c 'echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial/" >> /etc/apt/sources.list'
 - gpg --keyserver keyserver.ubuntu.com --recv-key E084DAB9
 - gpg -a --export E084DAB9 | sudo apt-key add -
 - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ dist:
 before_install:
 # install latest r
 - sudo sh -c 'echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial/" >> /etc/apt/sources.list'
-- gpg --keyserver keyserver.ubuntu.com --recv-key E084DAB9
-- gpg -a --export E084DAB9 | sudo apt-key add -
 - sudo apt-get update
 - sudo apt-get install r-base r-base-dev r-base-core r-recommended
 # from apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: true
 os:
 - linux
 dist:
-# take the latest supported version
+# take the latest supported LTS version
 - xenial
 
 # install dependencies

--- a/pyabc/external.py
+++ b/pyabc/external.py
@@ -9,6 +9,13 @@ Currently, the R language is supported.
     The rpy2 package needs to be installed to interface with the R language.
     Installation of rpy2 is optional if R support is not required.
     See also :ref:`installation of optional dependencies <install-optional>`.
+
+.. note::
+
+    Support of R via rpy2 is considered experimental. Currently, an rpy2
+    version <= 2.9.5 is required. Versions >= 3.0.0 do not work yet properly
+    for various reasons (see #116). R versions 3.4 and 3.5 have shown to work.
+    Should this not work on your system, consider accessing R script-based.
 """
 
 try:

--- a/pyabc/transition/model_selection.py
+++ b/pyabc/transition/model_selection.py
@@ -25,7 +25,7 @@ class GridSearchCV(GridSearchCVSKL):
 
     """
     def __init__(self, estimator=None, param_grid=None,
-                 scoring=None, fit_params=None,
+                 scoring=None,
                  n_jobs=1, iid=True, refit=True, cv=5,
                  verbose=0, pre_dispatch='2*n_jobs', error_score='raise',
                  return_train_score=True):
@@ -35,7 +35,7 @@ class GridSearchCV(GridSearchCVSKL):
         if param_grid is None:
             param_grid = {'scaling': np.linspace(0.05, 1.0, 5)}
 
-        super().__init__(estimator, param_grid, scoring, fit_params, n_jobs,
+        super().__init__(estimator, param_grid, scoring, n_jobs,
                          iid, refit, cv, verbose, pre_dispatch,
                          error_score, return_train_score)
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
                       "flask_bootstrap>=3.3.7.1.dev1", "flask>=1.0.2",
                       "bokeh>=0.13.0", "redis>=2.10.6",
                       "dill>=0.2.8.2", "gitpython>=2.1.11",
-                      "scikit-learn>=0.20.0", "matplotlib>=3.0.0",
+                      "scikit-learn>=0.21.2", "matplotlib>=3.0.0",
                       "sqlalchemy>=1.3.0", "click>=7.0",
                       "feather-format>=0.4.0", "bkcharts>=0.2",
                       "distributed>=1.23.3", "pygments>=2.2.0",


### PR DESCRIPTION
- update travis version to xenial (16.04) since rpy2 causes problems otherwise with dlopen (see #116)
- fix argument change in sklearn GridSearch, update to 0.21.2

This is only a preliminary fix, using an outdated R link, because the latest version of rpy2 could not be be completely included yet.