### PR TITLE
Feature dummydb

### DIFF
--- a/.travis_pip_reqs.txt
+++ b/.travis_pip_reqs.txt
@@ -25,6 +25,7 @@ feather-format
 bkcharts
 tzlocal
 rpy2>=3.2.0
+cffi==1.12.2
 flake8
 pytest
 codecov

--- a/pyabc/__init__.py
+++ b/pyabc/__init__.py
@@ -41,7 +41,9 @@ from .epsilon import (
     MedianEpsilon,
     ListEpsilon)
 from .smc import ABCSMC
-from .storage import History
+from .storage import (
+    History,
+    create_db_identifier)
 from .acceptor import (
     Acceptor,
     SimpleFunctionAcceptor,
@@ -123,6 +125,7 @@ __all__ = [
     "IntegratedModel",
     # history
     "History",
+    "create_db_identifier",
     # visualization
     "visualization",
 ]

--- a/pyabc/__init__.py
+++ b/pyabc/__init__.py
@@ -43,7 +43,7 @@ from .epsilon import (
 from .smc import ABCSMC
 from .storage import (
     History,
-    create_db_identifier)
+    create_sqlite_db_id)
 from .acceptor import (
     Acceptor,
     SimpleFunctionAcceptor,
@@ -125,7 +125,7 @@ __all__ = [
     "IntegratedModel",
     # history
     "History",
-    "create_db_identifier",
+    "create_sqlite_db_id",
     # visualization
     "visualization",
 ]

--- a/pyabc/storage/__init__.py
+++ b/pyabc/storage/__init__.py
@@ -84,6 +84,10 @@ In addition, it is also possible to store pandas DataFrames.
 
 """
 
-from .history import History
+from .history import History, create_db_identifier
 
-__all__ = ["History"]
+
+__all__ = [
+    "History",
+    "create_db_identifier",
+]

--- a/pyabc/storage/__init__.py
+++ b/pyabc/storage/__init__.py
@@ -84,10 +84,10 @@ In addition, it is also possible to store pandas DataFrames.
 
 """
 
-from .history import History, create_db_identifier
+from .history import History, create_sqlite_db_id
 
 
 __all__ = [
     "History",
-    "create_db_identifier",
+    "create_sqlite_db_id",
 ]

--- a/pyabc/storage/history.py
+++ b/pyabc/storage/history.py
@@ -8,6 +8,7 @@ import scipy as sp
 from sqlalchemy import func
 from sqlalchemy.orm import subqueryload
 from functools import wraps
+import tempfile
 import logging
 
 from .db_model import (ABCSMC, Population, Model, Particle,
@@ -59,6 +60,25 @@ def git_hash():
             git.exc.InvalidGitRepositoryError) as e:
         git_hash = str(e)
     return git_hash
+
+
+def create_db_identifier(dir_: str = None, file_: str = "pyabc_test.db"):
+    """
+    Create an sqlite database identifier.
+
+    Parameters
+    ----------
+    dir_:
+        The base folder name. Optional, defaults to the system's
+        temporary directory, i.e. "/tmp/" on Linux. While this makes
+        sense for testing purposes, for productive use a non-temporary
+        location should be used.
+    file_:
+        The database file name. Optional, defaults to "pyabc_test.db".
+    """
+    if dir_ is None:
+        dir_ = tempfile.gettempdir()
+    return "sqlite:///" + os.path.join(dir_, file_)
 
 
 class History:

--- a/pyabc/storage/history.py
+++ b/pyabc/storage/history.py
@@ -62,19 +62,22 @@ def git_hash():
     return git_hash
 
 
-def create_db_identifier(file_: str = "pyabc_test.db", dir_: str = None):
+def create_sqlite_db_id(
+        dir_: str = None,
+        file_: str = "pyabc_test.db"):
     """
-    Create an sqlite database identifier.
+    Convenience function to create an sqlite database identifier which
+    can be understood by sqlalchemy.
 
     Parameters
     ----------
-    file_:
-        The database file name. Optional, defaults to "pyabc_test.db".
     dir_:
         The base folder name. Optional, defaults to the system's
         temporary directory, i.e. "/tmp/" on Linux. While this makes
         sense for testing purposes, for productive use a non-temporary
         location should be used.
+    file_:
+        The database file name. Optional, defaults to "pyabc_test.db".
     """
     if dir_ is None:
         dir_ = tempfile.gettempdir()

--- a/pyabc/storage/history.py
+++ b/pyabc/storage/history.py
@@ -62,19 +62,19 @@ def git_hash():
     return git_hash
 
 
-def create_db_identifier(dir_: str = None, file_: str = "pyabc_test.db"):
+def create_db_identifier(file_: str = "pyabc_test.db", dir_: str = None):
     """
     Create an sqlite database identifier.
 
     Parameters
     ----------
+    file_:
+        The database file name. Optional, defaults to "pyabc_test.db".
     dir_:
         The base folder name. Optional, defaults to the system's
         temporary directory, i.e. "/tmp/" on Linux. While this makes
         sense for testing purposes, for productive use a non-temporary
         location should be used.
-    file_:
-        The database file name. Optional, defaults to "pyabc_test.db".
     """
     if dir_ is None:
         dir_ = tempfile.gettempdir()

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -1,5 +1,4 @@
 import os
-from tempfile import gettempdir
 import pytest
 
 import pyabc
@@ -38,7 +37,7 @@ def test_r(sampler):
     abc = pyabc.ABCSMC(model, prior, distance,
                        summary_statistics=sum_stat,
                        sampler=sampler)
-    db = "sqlite:///" + os.path.join(gettempdir(), "test_external.db")
+    db = pyabc.create_db_identifier("test_external.db")
     abc.new(db, r.observation("mySumStatData"))
     history = abc.run(minimum_epsilon=0.9, max_nr_populations=2)
     history.get_weighted_sum_stats_for_model(m=0, t=1)[1][0]["cars"].head()

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -37,7 +37,7 @@ def test_r(sampler):
     abc = pyabc.ABCSMC(model, prior, distance,
                        summary_statistics=sum_stat,
                        sampler=sampler)
-    db = pyabc.create_db_identifier("test_external.db")
+    db = pyabc.create_sqlite_db_id(file_="test_external.db")
     abc.new(db, r.observation("mySumStatData"))
     history = abc.run(minimum_epsilon=0.9, max_nr_populations=2)
     history.get_weighted_sum_stats_for_model(m=0, t=1)[1][0]["cars"].head()


### PR DESCRIPTION
* Add a function to simple generate an sqlite (test) database identifier to avoid those nasty three line imports in every test script.