### PR TITLE
Resample

### DIFF
--- a/pyabc/weighted_statistics.py
+++ b/pyabc/weighted_statistics.py
@@ -81,3 +81,19 @@ def effective_sample_size(weights):
     weights = np.array(weights)
     n_eff = np.sum(weights)**2 / np.sum(weights**2)
     return n_eff
+
+
+def resample(points, weights, n):
+    """
+    Resample from weighted samples.
+
+    Parameters
+    ----------
+    points: The random samples.
+    weights: Weights of each sample point.
+    n: Number of samples to resample.
+    """
+    weights = np.array(weights)
+    weights /= np.sum(weights)
+    resampled = np.random.choice(points, size=n, p=weights)
+    return resampled

--- a/pyabc/weighted_statistics.py
+++ b/pyabc/weighted_statistics.py
@@ -89,11 +89,72 @@ def resample(points, weights, n):
 
     Parameters
     ----------
-    points: The random samples.
-    weights: Weights of each sample point.
-    n: Number of samples to resample.
+    points:
+        The random samples.
+    weights:
+        Weights of each sample point.
+    n:
+        Number of samples to resample.
+
+    Returns
+    -------
+    resampled:
+        A total of `n` points sampled from `points` with putting back
+        according to `weights`.
     """
     weights = np.array(weights)
     weights /= np.sum(weights)
     resampled = np.random.choice(points, size=n, p=weights)
+    return resampled
+
+
+def resample_deterministic(points, weights, n, enforce_n=False):
+    """
+    Resample from weighted samples in a deterministic manner. Essentially,
+    multiplicities are picked as follows:
+    The weights are multiplied by the target number `n` and rounded to the
+    nearest integer, potentially with correction if `enforce_n`.
+
+    Parameters
+    ----------
+    points:
+        The random samples.
+    weights:
+        Weights of each sample point.
+    n:
+        Number of samples to resample.
+    enforce_n:
+        Whether to enforce the returned array to have length `n`.
+        If not, its length can be slightly off, but it may be more
+        representative.
+
+    Returns
+    -------
+    resampled:
+        A total of (roughly) `n` points resampled from `points`
+        deterministically using a rational representation of the `weights`.
+    """
+    weights = np.array(weights)
+    numbers_f = weights * (n / np.sum(weights))
+
+    numbers = np.round(numbers_f)
+
+    # enforce return array length
+    if enforce_n and np.sum(numbers) != n:
+        residuals = numbers_f - numbers
+        # sort the residuals mon. inc.
+        order = np.argsort(residuals)
+        # increment numbers with largest offsets
+        while np.sum(numbers) < n:
+            numbers[order[-1]] += 1
+            order = order[:-1]
+        # decrement numbers with largest negative offsets
+        while np.sum(numbers) > n:
+            numbers[order[0]] -= 1
+            order = order[1:]
+
+    resampled = []
+    for i, ni in enumerate(numbers):
+        resampled.extend([points[i]] * int(ni))
+
     return resampled

--- a/test/test_weighted_statistics.py
+++ b/test/test_weighted_statistics.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+from scipy.stats import ks_2samp
 import pyabc.weighted_statistics as ws
 
 
@@ -37,3 +37,30 @@ def test_weighted_std():
     std_ = np.sqrt(np.sum(weights * (points - m_)**2))
 
     assert std == std_
+
+
+def test_resample():
+    """
+    Test that the resampling process yields consistent distributions,
+    using a KS test.
+    """
+    nw = 50  # number of weighted points
+    points = np.random.randn(nw)
+    weights = np.random.rand(nw)
+    weights /= np.sum(weights)
+
+    n = 1000  # number of non-weighted points
+    # sample twice from same samples
+    resampled1 = ws.resample(points, weights, n)
+    resampled2 = ws.resample(points, weights, n)
+
+    # should be same distribution
+    D, p = ks_2samp(resampled1, resampled2)
+    assert p > 1e-2
+
+    # use different points
+    points3 = np.random.randn(nw)
+    resampled3 = ws.resample(points3, weights, n)
+    # should be different distributions
+    D, p = ks_2samp(resampled1, resampled3)
+    assert p < 1e-2

--- a/test/test_weighted_statistics.py
+++ b/test/test_weighted_statistics.py
@@ -55,7 +55,7 @@ def test_resample():
     resampled2 = ws.resample(points, weights, n)
 
     # should be same distribution
-    D, p = ks_2samp(resampled1, resampled2)
+    _, p = ks_2samp(resampled1, resampled2)
     assert p > 1e-2
 
     # use different points

--- a/test/test_weighted_statistics.py
+++ b/test/test_weighted_statistics.py
@@ -62,5 +62,30 @@ def test_resample():
     points3 = np.random.randn(nw)
     resampled3 = ws.resample(points3, weights, n)
     # should be different distributions
-    D, p = ks_2samp(resampled1, resampled3)
+    _, p = ks_2samp(resampled1, resampled3)
     assert p < 1e-2
+
+
+def test_resample_deterministic():
+    """
+    Test the deterministic resampling routine.
+    """
+    nw = 50  # number of weighed points
+    points = np.random.randn(nw)
+    weights = np.random.rand(nw)
+    weights /= np.sum(weights)
+
+    n = 1000  # number of non-weighted points
+    resampled_det = ws.resample_deterministic(points, weights, n, False)
+
+    resampled = ws.resample(points, weights, n)
+
+    # should be same distribution
+    _, p = ks_2samp(resampled_det, resampled)
+    assert p > 1e-2
+
+    resampled_det2 = ws.resample_deterministic(points, weights, n, True)
+    assert len(resampled_det2) == n
+
+    _, p = ks_2samp(resampled_det2, resampled)
+    assert p > 1e-2


### PR DESCRIPTION
Resample from the set of weighted particles, according to the weigts. This allows to use statistical tools operating on non-weighted samples.

NOTE: Does not perform any heterogenization, i.e. the resulting particles are just taken from the original particles, not perturbed / random-walked.