### PR TITLE
Feature listpopulationsize (#274)

### DIFF
--- a/doc/releasenotes.rst
+++ b/doc/releasenotes.rst
@@ -8,7 +8,7 @@ Release Notes
 ...........
 
 
-0.10.0 (2020-02-18)
+0.10.0 (2020-02-20)
 -------------------
 
 * Exact inference via stochastic acceptor finalized and tested (developed
@@ -17,6 +17,8 @@ Release Notes
 * Various error fixes (#265, #267).
 * Log number of processes used by multiprocessing samplers (#263).
 * Implement pyabc.acceptor.ScaledPDFNorm (#269).
+* Implement list population size (#274, #276).
+* On history loading, automatically find an id of a successful run (#273).
 
 
 0.9 series

--- a/pyabc/populationstrategy.py
+++ b/pyabc/populationstrategy.py
@@ -108,7 +108,7 @@ class ConstantPopulationSize(PopulationStrategy):
         Number of samples to draw for a proposed parameter
     """
 
-    def adapt_population_size(self, transitions, model_weights):
+    def adapt_population_size(self, transitions, model_weights, t):
         pass
 
 
@@ -177,7 +177,7 @@ class AdaptivePopulationSize(PopulationStrategy):
                 "mean_cv": self.mean_cv}
 
     def adapt_population_size(self, transitions: List[Transition],
-                              model_weights: np.ndarray):
+                              model_weights: np.ndarray, t: int):
         test_X = [trans.X for trans in transitions]
         test_w = [trans.w for trans in transitions]
 
@@ -196,3 +196,31 @@ class AdaptivePopulationSize(PopulationStrategy):
 
         logger.info("Change nr particles {} -> {}"
                     .format(reference_nr_part, self.nr_particles))
+
+        
+class ListPopulationSize(PopulationStrategy):
+    """
+    Return PopulationSize values from a predefined list. For every time point
+    enquired later, a PopulationSize value must exist in the list.
+    
+    Parameters
+    ----------
+    values: List[float]
+        List of PopulationSize values.
+        ``values[t]`` is the value for population t.
+    """
+
+    def __init__(self,
+                 values: List[float]):
+        super().__init__(nr_particles=list(values)[0])
+        self.population_values = list(values)
+        
+    def get_config(self):
+        config = super().get_config()
+        config["population_values"] = self.population_values
+        return config
+
+    def adapt_population_size(self, transitions: List[Transition],
+                              model_weights: np.ndarray,
+                              t: int):
+        self.nr_particles = self.population_values[t]

--- a/pyabc/populationstrategy.py
+++ b/pyabc/populationstrategy.py
@@ -199,12 +199,12 @@ class AdaptivePopulationSize(PopulationStrategy):
         logger.info("Change nr particles {} -> {}"
                     .format(reference_nr_part, self.nr_particles))
 
-        
+
 class ListPopulationSize(PopulationStrategy):
     """
     Return population size values from a predefined list. For every time point
     enquired later (specified by time t), an entry must exist in the list.
-    
+
     Parameters
     ----------
     values: List[float]
@@ -216,7 +216,7 @@ class ListPopulationSize(PopulationStrategy):
                  values: List[float]):
         super().__init__(nr_particles=list(values)[0])
         self.population_values = list(values)
-        
+
     def get_config(self):
         config = super().get_config()
         config["population_values"] = self.population_values

--- a/pyabc/populationstrategy.py
+++ b/pyabc/populationstrategy.py
@@ -51,7 +51,7 @@ class PopulationStrategy:
         self.nr_samples_per_parameter = nr_samples_per_parameter
 
     def adapt_population_size(self, transitions: List[Transition],
-                              model_weights: np.ndarray):
+                              model_weights: np.ndarray, t: int = None):
         """
         Select the population size for the next population.
 
@@ -59,6 +59,7 @@ class PopulationStrategy:
         ----------
         transitions: List of Transitions
         model_weights: array of model weights
+        t: Time to adapt for
 
         Returns
         -------
@@ -108,7 +109,8 @@ class ConstantPopulationSize(PopulationStrategy):
         Number of samples to draw for a proposed parameter
     """
 
-    def adapt_population_size(self, transitions, model_weights, t):
+    def adapt_population_size(self, transitions: List[Transition],
+                              model_weights: np.ndarray, t: int = None):
         pass
 
 
@@ -177,7 +179,7 @@ class AdaptivePopulationSize(PopulationStrategy):
                 "mean_cv": self.mean_cv}
 
     def adapt_population_size(self, transitions: List[Transition],
-                              model_weights: np.ndarray, t: int):
+                              model_weights: np.ndarray, t: int = None):
         test_X = [trans.X for trans in transitions]
         test_w = [trans.w for trans in transitions]
 
@@ -200,13 +202,13 @@ class AdaptivePopulationSize(PopulationStrategy):
         
 class ListPopulationSize(PopulationStrategy):
     """
-    Return PopulationSize values from a predefined list. For every time point
-    enquired later, a PopulationSize value must exist in the list.
+    Return population size values from a predefined list. For every time point
+    enquired later (specified by time t), an entry must exist in the list.
     
     Parameters
     ----------
     values: List[float]
-        List of PopulationSize values.
+        List of population size values.
         ``values[t]`` is the value for population t.
     """
 
@@ -221,6 +223,5 @@ class ListPopulationSize(PopulationStrategy):
         return config
 
     def adapt_population_size(self, transitions: List[Transition],
-                              model_weights: np.ndarray,
-                              t: int):
+                              model_weights: np.ndarray, t: int = None):
         self.nr_particles = self.population_values[t]

--- a/pyabc/smc.py
+++ b/pyabc/smc.py
@@ -912,6 +912,10 @@ class ABCSMC:
             logger.info(f"Acceptance rate: {pop_size} / {n_sim} = "
                         f"{acceptance_rate:.4e}, ESS={ess:.4e}.")
 
+            # prepare next iteration
+            self._prepare_next_iteration(
+                t+1, sample, population, acceptance_rate)
+
             # check termination conditions
             if current_eps <= minimum_epsilon:
                 logger.info("Stopping: minimum epsilon.")
@@ -923,13 +927,7 @@ class ABCSMC:
             elif acceptance_rate < min_acceptance_rate:
                 logger.info("Stopping: minimum acceptance rate.")
                 break
-            elif t==t_max:
-                break
-                
-            # prepare next iteration
-            self._prepare_next_iteration(
-                t+1, sample, population, acceptance_rate)
-                
+
             # increment t
             t += 1
 
@@ -1042,7 +1040,8 @@ class ABCSMC:
         # WARNING: the deepcopy also copies the random states of scipy.stats
         # distributions
         copied_transitions = copy.deepcopy(self.transitions)
-        self.population_strategy.adapt_population_size(copied_transitions, w, t)
+        self.population_strategy.adapt_population_size(
+            copied_transitions, w, t)
 
     def _fit_transitions(self, t):
         """

--- a/pyabc/smc.py
+++ b/pyabc/smc.py
@@ -912,10 +912,6 @@ class ABCSMC:
             logger.info(f"Acceptance rate: {pop_size} / {n_sim} = "
                         f"{acceptance_rate:.4e}, ESS={ess:.4e}.")
 
-            # prepare next iteration
-            self._prepare_next_iteration(
-                t+1, sample, population, acceptance_rate)
-
             # check termination conditions
             if current_eps <= minimum_epsilon:
                 logger.info("Stopping: minimum epsilon.")
@@ -927,7 +923,13 @@ class ABCSMC:
             elif acceptance_rate < min_acceptance_rate:
                 logger.info("Stopping: minimum acceptance rate.")
                 break
-
+            elif t==t_max:
+                break
+                
+            # prepare next iteration
+            self._prepare_next_iteration(
+                t+1, sample, population, acceptance_rate)
+                
             # increment t
             t += 1
 
@@ -1040,7 +1042,7 @@ class ABCSMC:
         # WARNING: the deepcopy also copies the random states of scipy.stats
         # distributions
         copied_transitions = copy.deepcopy(self.transitions)
-        self.population_strategy.adapt_population_size(copied_transitions, w)
+        self.population_strategy.adapt_population_size(copied_transitions, w, t)
 
     def _fit_transitions(self, t):
         """

--- a/test/test_populationstrategy.py
+++ b/test/test_populationstrategy.py
@@ -112,4 +112,5 @@ def test_transitions_not_modified(population_strategy: PopulationStrategy):
 
    
 def test_list_population_size():
+    """Test list population size."""
     pop_size = pyabc.ListPopulationSize(values=[10, 5, 1.5])

--- a/test/test_populationstrategy.py
+++ b/test/test_populationstrategy.py
@@ -1,5 +1,6 @@
 import pytest
-from pyabc.populationstrategy import (AdaptivePopulationSize,
+from pyabc.populationstrategy import (ListPopulationSize,
+                                      AdaptivePopulationSize,
                                       ConstantPopulationSize,
                                       PopulationStrategy)
 from pyabc.transition import MultivariateNormalTransition
@@ -108,3 +109,7 @@ def test_transitions_not_modified(population_strategy: PopulationStrategy):
                " modified the transitions".format(population_strategy))
 
     assert same, err_msg
+
+   
+def test_ListPopulationSize():
+    pop_size = pyabc.ListPopulationSize(values=[10, 5, 1.5])

--- a/test/test_populationstrategy.py
+++ b/test/test_populationstrategy.py
@@ -110,7 +110,11 @@ def test_transitions_not_modified(population_strategy: PopulationStrategy):
 
     assert same, err_msg
 
-   
+
 def test_list_population_size():
     """Test list population size."""
-    pop_size = pyabc.ListPopulationSize(values=[10, 5, 1.5])
+    pop_size = ListPopulationSize(values=[100, 1000, 1000])
+    pop_size.adapt_population_size(None, None, 0)
+    assert pop_size.nr_particles == 100
+    pop_size.adapt_population_size(None, None, 2)
+    assert pop_size.nr_particles == 1000

--- a/test/test_populationstrategy.py
+++ b/test/test_populationstrategy.py
@@ -111,5 +111,5 @@ def test_transitions_not_modified(population_strategy: PopulationStrategy):
     assert same, err_msg
 
    
-def test_ListPopulationSize():
+def test_list_population_size():
     pop_size = pyabc.ListPopulationSize(values=[10, 5, 1.5])


### PR DESCRIPTION
* Init ListPopulation

ListPopulation provides user definded population sizes which are comitted using a list. It's implementation follows the ListEpsilon case. List must have as many entries as populations are to be run.

* Add t argument to adapt_population_size

We will need to configure smc class such that it passes t as an argument to the _adapt_population_size. Therefor all adapt_population_size function have to be given t as well.

* Adapt smc.run to ListPopulation

In order to use ListPopulation we need to break before the _prepare_next_iteration in the end. 
Also pass t to _adapt_population_size

* Update populationstrategy.py

* Pass argumentname for better readability

* Rename class

Class name should contain Size as well

* Added test for ListPopulationSize

Simple test for ListPopulationSize according to the test_ListEpsilon function.

* Add get_config function in ListPopulationSize

Added get_config class according to ListEpsilon.get_config() function

* Reformat code

Added t==t_max other code termination block. Did not add logger info because while loop would not have produced a logger info itself.

* Modify documentation

Changed Population values to PopulationSize values

* Add empty line for doc parsing

* Remove empty line

* Remove assertions

Assertions didnt work.

Co-authored-by: Yannik Schälte <31767307+yannikschaelte@users.noreply.github.com>