### PR TITLE
Implement optional pickling for multicore samplers

### DIFF
--- a/.github/workflows/ci_dependencies.sh
+++ b/.github/workflows/ci_dependencies.sh
@@ -23,7 +23,7 @@ do
 
     R)
 	    # R environment
-	    if [ "$(uname)" == "Darwin" ]; then
+      if [ "$(uname)" == "Darwin" ]; then
         # MacOS
         brew install r
       else

--- a/.github/workflows/ci_dependencies.sh
+++ b/.github/workflows/ci_dependencies.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
 
-# apt
-sudo apt-get update
-sudo apt-get install redis-server
+if [ "$(uname)" == "Linux" ]; then
+    # apt
+    sudo apt-get update
+    sudo apt-get install redis-server
+else
+    brew install redis
+fi
 
 # pip
 python -m pip install --upgrade pip

--- a/.github/workflows/ci_dependencies.sh
+++ b/.github/workflows/ci_dependencies.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 
-if [ "$(uname)" == "Linux" ]; then
-    # apt
+if [ "$(uname)" == "Darwin" ]; then
+    # MacOS
+    brew install redis
+else
+    # Linux
     sudo apt-get update
     sudo apt-get install redis-server
-else
-    brew install redis
 fi
 
 # pip

--- a/.github/workflows/ci_dependencies.sh
+++ b/.github/workflows/ci_dependencies.sh
@@ -1,13 +1,8 @@
 #!/bin/sh
 
-if [ "$(uname)" == "Darwin" ]; then
-  # MacOS
-  brew install redis
-else
-  # Linux
-  sudo apt-get update
-  sudo apt-get install redis-server
-fi
+sudo apt-get update
+# redis
+sudo apt-get install redis-server
 
 # pip
 python -m pip install --upgrade pip
@@ -23,24 +18,18 @@ do
 
     R)
 	    # R environment
-	    if [ "$(uname)" == "Darwin" ]; then
-        # MacOS
-        brew install r
-      else
-        # Linux
-        sudo apt-key adv \
-          --keyserver keyserver.ubuntu.com \
-          --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
-        sudo add-apt-repository \
-          'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
-        sudo apt-get update
-        sudo apt-get install r-base
-      fi
+      sudo apt-key adv \
+        --keyserver keyserver.ubuntu.com \
+        --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+      sudo add-apt-repository \
+        'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
+      sudo apt-get update
+      sudo apt-get install r-base
       pip install rpy2>=3.2.0 cffi>=1.13.1
     ;;
 
     petab)
-	    # PEtab
+	    # PEtab dependencies
       sudo apt-get install swig3.0 libatlas-base-dev libhdf5-serial-dev
       sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
       pip install https://github.com/icb-dcm/petab/archive/develop.zip

--- a/.github/workflows/ci_dependencies.sh
+++ b/.github/workflows/ci_dependencies.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 
-sudo apt-get update
-# redis
-sudo apt-get install redis-server
+if [ "$(uname)" == "Darwin" ]; then
+  # MacOS
+  brew install redis
+else
+  # Linux
+  sudo apt-get update
+  sudo apt-get install redis-server
+fi
 
 # pip
 python -m pip install --upgrade pip
@@ -18,18 +23,24 @@ do
 
     R)
 	    # R environment
-      sudo apt-key adv \
-        --keyserver keyserver.ubuntu.com \
-        --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
-      sudo add-apt-repository \
-        'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
-      sudo apt-get update
-      sudo apt-get install r-base
+	    if [ "$(uname)" == "Darwin" ]; then
+        # MacOS
+        brew install r
+      else
+        # Linux
+        sudo apt-key adv \
+          --keyserver keyserver.ubuntu.com \
+          --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+        sudo add-apt-repository \
+          'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
+        sudo apt-get update
+        sudo apt-get install r-base
+      fi
       pip install rpy2>=3.2.0 cffi>=1.13.1
     ;;
 
     petab)
-	    # PEtab dependencies
+	    # PEtab
       sudo apt-get install swig3.0 libatlas-base-dev libhdf5-serial-dev
       sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
       pip install https://github.com/icb-dcm/petab/archive/develop.zip

--- a/.github/workflows/ci_dependencies.sh
+++ b/.github/workflows/ci_dependencies.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 if [ "$(uname)" == "Darwin" ]; then
-    # MacOS
-    brew install redis
+  # MacOS
+  brew install redis
 else
-    # Linux
-    sudo apt-get update
-    sudo apt-get install redis-server
+  # Linux
+  sudo apt-get update
+  sudo apt-get install redis-server
 fi
 
 # pip
@@ -19,35 +19,41 @@ pip install -e .
 # optional dependencies
 for par in "$@"
 do
-    case $par in
+  case $par in
 
-        R)
+    R)
 	    # R environment
-            sudo apt-key adv \
-                --keyserver keyserver.ubuntu.com \
-                --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
-            sudo add-apt-repository \
-                'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
-            sudo apt-get update
-            sudo apt-get install r-base
-            pip install rpy2>=3.2.0 cffi>=1.13.1
-        ;;
+	    if [ "$(uname)" == "Darwin" ]; then
+        # MacOS
+        brew install r
+      else
+        # Linux
+        sudo apt-key adv \
+          --keyserver keyserver.ubuntu.com \
+          --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+        sudo add-apt-repository \
+          'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
+        sudo apt-get update
+        sudo apt-get install r-base
+      fi
+      pip install rpy2>=3.2.0 cffi>=1.13.1
+    ;;
 
-        petab)
+    petab)
 	    # PEtab
-            sudo apt-get install swig3.0 libatlas-base-dev libhdf5-serial-dev
-            sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
-            pip install https://github.com/icb-dcm/petab/archive/develop.zip
-            pip install -e \
-                'git+https://github.com/icb-dcm/amici.git@develop#egg=amici&subdirectory=python/sdist'
-            git clone --depth 1 \
-                https://github.com/petab-dev/petab_test_suite .tmp/petab_test_suite
-            pip install -e .tmp/petab_test_suite
-        ;;
+      sudo apt-get install swig3.0 libatlas-base-dev libhdf5-serial-dev
+      sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
+      pip install https://github.com/icb-dcm/petab/archive/develop.zip
+      pip install -e \
+        'git+https://github.com/icb-dcm/amici.git@develop#egg=amici&subdirectory=python/sdist'
+      git clone --depth 1 \
+        https://github.com/petab-dev/petab_test_suite .tmp/petab_test_suite
+      pip install -e .tmp/petab_test_suite
+    ;;
 
-        *)
-            echo "Unknown argument" >&2
-	    exit 1
-        ;;
-    esac
+    *)
+      echo "Unknown argument" >&2
+	  exit 1
+    ;;
+  esac
 done

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -5,9 +5,10 @@ on: [push]
 
 jobs:
   base:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.8]
 
     steps:

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -143,8 +143,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 10
         run: |
-          python -m pytest --cov=pyabc --cov-report=xml \
-            test/test_samplers.py
+          python -m pytest --cov=pyabc --cov-report=xml test/test_macos.py
 
       - name: Coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -27,7 +27,7 @@ jobs:
         restore-keys: ${{ runner.os }}-
 
     - name: Install dependencies
-      run: .github/workflows/ci_dependencies.sh R
+      run: .github/workflows/ci_dependencies.sh
 
     - name: Run tests
       timeout-minutes: 10

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -5,7 +5,7 @@ on: [push]
 
 jobs:
   base:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         python-version: [3.8]

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -5,10 +5,9 @@ on: [push]
 
 jobs:
   base:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
         python-version: [3.8]
 
     steps:
@@ -115,3 +114,40 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
+
+  mac:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Prepare python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-ci-base
+          restore-keys: ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: .github/workflows/ci_dependencies.sh
+
+      - name: Run tests
+        timeout-minutes: 10
+        run: |
+          python -m pytest --cov=pyabc --cov-report=xml \
+            test/test_samplers.py
+
+      - name: Coverage
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -27,7 +27,7 @@ jobs:
         restore-keys: ${{ runner.os }}-
 
     - name: Install dependencies
-      run: .github/workflows/ci_dependencies.sh
+      run: .github/workflows/ci_dependencies.sh R
 
     - name: Run tests
       timeout-minutes: 10

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -141,7 +141,7 @@ jobs:
         run: .github/workflows/ci_dependencies.sh
 
       - name: Run tests
-        timeout-minutes: 10
+        timeout-minutes: 5
         run: |
           python -m pytest --cov=pyabc --cov-report=xml test/test_macos.py
 

--- a/pyabc/platform_factory.py
+++ b/pyabc/platform_factory.py
@@ -3,7 +3,7 @@ from .sampler import MulticoreEvalParallelSampler, SingleCoreSampler
 
 
 _linux = {"sampler": MulticoreEvalParallelSampler}
-_macos = {"sampler": SingleCoreSampler}
+_macos = {"sampler": MulticoreEvalParallelSampler}
 _windows = {"sampler": SingleCoreSampler}
 
 if platform.system() == "Windows":

--- a/pyabc/platform_factory.py
+++ b/pyabc/platform_factory.py
@@ -3,7 +3,14 @@ from .sampler import MulticoreEvalParallelSampler, SingleCoreSampler
 
 
 _linux = {"sampler": MulticoreEvalParallelSampler}
+_macos = {"sampler": SingleCoreSampler}
 _windows = {"sampler": SingleCoreSampler}
-_platform_factory = _windows if platform.system() == "Windows" else _linux
+
+if platform.system() == "Windows":
+    _platform_factory = _windows
+elif platform.system() == "Darwin":
+    _platform_factory = _macos
+else:
+    _platform_factory = _linux
 
 DefaultSampler = _platform_factory["sampler"]

--- a/pyabc/sampler/multicore_evaluation_parallel.py
+++ b/pyabc/sampler/multicore_evaluation_parallel.py
@@ -19,7 +19,7 @@ def work(simulate_one,
          max_eval: int,
          all_accepted: bool,
          sample_factory):
-    # unwrap args
+    # unwrap arguments
     if isinstance(simulate_one, bytes):
         simulate_one = pickle.loads(simulate_one)
 
@@ -98,7 +98,7 @@ class MulticoreEvalParallelSampler(MultiCoreSampler):
 
         queue = Queue()
 
-        # wrap args
+        # wrap arguments
         if self.pickle:
             simulate_one = pickle.dumps(simulate_one)
         args = (simulate_one, queue,

--- a/pyabc/sampler/multicorebase.py
+++ b/pyabc/sampler/multicorebase.py
@@ -3,6 +3,7 @@ from multiprocessing import ProcessError, Process, Queue
 from queue import Empty
 from typing import List
 import os
+import platform
 import logging
 
 logger = logging.getLogger("Sampler")
@@ -27,10 +28,16 @@ class MultiCoreSampler(Sampler):
     def __init__(self,
                  n_procs: int = None,
                  daemon: bool = True,
+                 pickle: bool = None,
                  check_max_eval: bool = False):
         super().__init__()
         self._n_procs = n_procs
         self.daemon = daemon
+        if pickle is None:
+            pickle = False
+            if platform.system() == "Darwin":  # macos
+                pickle = True
+        self.pickle = pickle
         self.check_max_eval = check_max_eval
 
         # inform user about number of cores used

--- a/pyabc/sampler/multicorebase.py
+++ b/pyabc/sampler/multicorebase.py
@@ -21,6 +21,10 @@ class MultiCoreSampler(Sampler):
         Number of processes.
     daemon: bool
         Whether to spawn workers in daemon mode.
+    pickle:
+        Whether to manually pickle (we employ cloudpickle) certain objects
+        that are passed to the parallel processes. This may be necessary on
+        some systems, while pickling is usually not necessary at all on Linux.
     check_max_eval: bool
         Whether to check the maximum number of evaluations on the fly.
     """

--- a/test/test_macos.py
+++ b/test/test_macos.py
@@ -1,0 +1,36 @@
+"""Test some basic functionality of pyabc on mac."""
+
+import pytest
+import numpy as np
+
+import pyabc
+
+
+@pytest.fixture(params=[pyabc.SingleCoreSampler,
+                        pyabc.MulticoreEvalParallelSampler,
+                        pyabc.MulticoreParticleParallelSampler,
+                        ])
+def sampler(request):
+    s = request.param()
+    yield s
+    try:
+        s.cleanup()
+    except AttributeError:
+        pass
+
+
+def test_basic(sampler: pyabc.sampler.Sampler):
+    """Some basic tests."""
+    def model(par):
+        return {'s0': par['p0'] + np.random.randn(4)}
+
+    def distance(x, y):
+        return np.sum(x['s0'] - y['s0'])
+
+    x0 = model({'p0': 2})
+    prior = pyabc.Distribution(p0=pyabc.RV("uniform", 0, 10))
+
+    abc = pyabc.ABCSMC(
+        model, prior, distance, sampler=sampler, population_size=50)
+    abc.new(pyabc.create_sqlite_db_id(), x0)
+    abc.run(max_nr_populations=4)

--- a/test/test_macos.py
+++ b/test/test_macos.py
@@ -6,7 +6,8 @@ import numpy as np
 import pyabc
 
 
-@pytest.fixture(params=[pyabc.SingleCoreSampler,
+@pytest.fixture(params=[lambda: None,
+                        pyabc.SingleCoreSampler,
                         pyabc.MulticoreEvalParallelSampler,
                         pyabc.MulticoreParticleParallelSampler,
                         ])

--- a/test/test_samplers.py
+++ b/test/test_samplers.py
@@ -74,11 +74,21 @@ def RedisEvalParallelSamplerServerStarterWrapper():
     return RedisEvalParallelSamplerServerStarter(batch_size=5)
 
 
+def PicklingMulticoreParticleParallelSampler():
+    return MulticoreParticleParallelSampler(pickle=True)
+
+
+def PicklingMulticoreEvalParallelSampler():
+    return MulticoreEvalParallelSampler(pickle=True)
+
+
 @pytest.fixture(params=[SingleCoreSampler,
                         RedisEvalParallelSamplerServerStarterWrapper,
                         MulticoreEvalParallelSampler,
                         MultiProcessingMappingSampler,
                         MulticoreParticleParallelSampler,
+                        PicklingMulticoreParticleParallelSampler,
+                        PicklingMulticoreEvalParallelSampler,
                         MappingSampler,
                         DaskDistributedSampler,
                         DaskDistributedSamplerBatch,


### PR DESCRIPTION
This should enable using the multicore samplers on systems where multiprocessing pickles arguments (e.g. macos with python3.8).

Adds a basic pipeline test on MacOS systems, however the general test suite does not run (multiple errors with redis and processes ...). Could be extended, but should be fine for the moment, considering MacOS support tentative.

Fixes #286.