### PR TITLE
Allow subprocessing in multiprocessed redis workers

### DIFF
--- a/pyabc/sampler/redis_eps/cli.py
+++ b/pyabc/sampler/redis_eps/cli.py
@@ -249,7 +249,7 @@ def work(host="localhost",
     """
     if processes == 1:
         # for a single process, no need to use any pooling
-        return _work(host, port, runtime, password, daemon, catch)
+        return _work(host, port, runtime, password, catch)
 
     # define parallel processes
     procs = [

--- a/pyabc/sampler/redis_eps/cli.py
+++ b/pyabc/sampler/redis_eps/cli.py
@@ -7,7 +7,7 @@ import os
 import cloudpickle
 from time import time
 import click
-from multiprocessing import Pool
+from multiprocessing import Process
 import numpy as np
 import random
 import logging
@@ -235,25 +235,40 @@ def work_on_population(analysis_id: str,
               help='Password for a secure connection.')
 @click.option('--processes', default=1, type=int,
               help="The number of worker processes to start")
+@click.option('--daemon', default=None, type=bool,
+              help="Create subprocesses in daemon mode.")
 @click.option('--catch', default=True, type=bool, help="Catch errors.")
 def work(host="localhost",
          port=6379, runtime="2h",
          password=None,
          processes=1,
+         daemon=None,
          catch=True):
-    """
+    """Start workers.
     Corresponds to the entry point abc-redis-worker.
     """
     if processes == 1:
-        # start a single process right here, not within pool
-        # this handles the problem of starting a daemon process within a
-        # daemon process
-        return _work(host, port, runtime, password, catch)
+        # for a single process, no need to use any pooling
+        return _work(host, port, runtime, password, daemon, catch)
 
-    with Pool(processes) as pool:
-        res = pool.starmap(_work, [(host, port, runtime, password, catch)]
-                           * processes)
-    return res
+    # define parallel processes
+    procs = [
+        Process(target=_work,
+                args=(host, port, runtime, password, catch),
+                daemon=daemon)
+        for _ in range(processes)]
+
+    # start them
+    for proc in procs:
+        proc.start()
+
+    # log
+    for proc in procs:
+        logger.info(f"Started subprocess with pid {proc.pid}")
+
+    # wait for them to return
+    for proc in procs:
+        proc.join()
 
 
 def _work(host="localhost", port=6379, runtime="2h", password=None,
@@ -330,7 +345,7 @@ def _work(host="localhost", port=6379, runtime="2h", password=None,
               help="Generation t.")
 @click.argument('command', type=str)
 def manage(command, host="localhost", port=6379, password=None, t=None):
-    """
+    """Manage workers.
     Corresponds to the entry point abc-redis-manager.
     """
     return _manage(command, host=host, port=port, password=password, t=t)

--- a/pyabc/sampler/redis_eps/cli.py
+++ b/pyabc/sampler/redis_eps/cli.py
@@ -235,14 +235,14 @@ def work_on_population(analysis_id: str,
               help='Password for a secure connection.')
 @click.option('--processes', default=1, type=int,
               help="The number of worker processes to start")
-@click.option('--daemon', default=None, type=bool,
+@click.option('--daemon', default=True, type=bool,
               help="Create subprocesses in daemon mode.")
 @click.option('--catch', default=True, type=bool, help="Catch errors.")
 def work(host="localhost",
          port=6379, runtime="2h",
          password=None,
          processes=1,
-         daemon=None,
+         daemon=True,
          catch=True):
     """Start workers.
     Corresponds to the entry point abc-redis-worker.

--- a/pyabc/sampler/redis_eps/redis_sampler_server_starter.py
+++ b/pyabc/sampler/redis_eps/redis_sampler_server_starter.py
@@ -23,6 +23,7 @@ class RedisEvalParallelSamplerServerStarter(RedisEvalParallelSampler):
                  look_ahead_delay_evaluation=True,
                  workers: int = 2,
                  processes_per_worker: int = 1,
+                 daemon: bool = True,
                  catch: bool = True,
                  log_file: str = None,
                  ):
@@ -56,12 +57,14 @@ class RedisEvalParallelSamplerServerStarter(RedisEvalParallelSampler):
 
         # initiate worker processes
         maybe_password = [] if password is None else ["--password", password]
+        maybe_daemon = [] if daemon is None else ["--daemon", str(daemon)]
         self.__worker = [
             Process(target=work,
                     args=(["--host", "localhost",
                            "--port", str(port),
                            *maybe_password,
                            "--processes", str(processes_per_worker),
+                           *maybe_daemon,
                            "--catch", str(catch)],),
                     daemon=False)
             for _ in range(workers)

--- a/pyabc/sge/db.py
+++ b/pyabc/sge/db.py
@@ -48,7 +48,7 @@ class SQLiteJobDB:
         #  pre-calculated expressions
         with self.connection:
             results = self.connection.execute(
-                "SELECT status, time from status WHERE ID="  # noqa: S608
+                "SELECT status, time from status WHERE ID="  # noqa: S608, B608
                 + str(ID)).fetchall()
             nr_rows = len(results)
 

--- a/test/base/test_samplers.py
+++ b/test/base/test_samplers.py
@@ -357,7 +357,7 @@ def test_redis_subprocess():
         return np.abs(y1['y'] - y2['y']).sum()
 
     obs = {'y': 1}
-    # False and None as daemon arguments are ok, True is not allowed
+    # False as daemon argument is ok, True and None are not allowed
     sampler = RedisEvalParallelSamplerServerStarter(
         workers=1, processes_per_worker=2, daemon=False)
     try:
@@ -365,7 +365,7 @@ def test_redis_subprocess():
             model, prior, distance, sampler=sampler,
             population_size=10)
         abc.new(pyabc.create_sqlite_db_id(), obs)
-        # will just never return if model evaluation fails
+        # would just never return if model evaluation fails
         abc.run(max_nr_populations=3)
     finally:
         sampler.shutdown()

--- a/test/base/test_samplers.py
+++ b/test/base/test_samplers.py
@@ -332,6 +332,45 @@ def test_redis_continuous_analyses():
         sampler.shutdown()
 
 
+def test_redis_subprocess():
+    """Test whether the instructed redis sampler allows worker subprocesses."""
+    # print worker output
+    logging.getLogger("Redis-Worker").addHandler(logging.StreamHandler())
+
+    def model_process(p, pipe):
+        """The actual model."""
+        pipe.send({"y": p['p0'] + 0.1 * np.random.randn(10)})
+
+    def model(p):
+        """Model calling a subprocess."""
+        parent, child = multiprocessing.Pipe()
+        proc = multiprocessing.Process(target=model_process, args=(p, child))
+        proc.start()
+        res = parent.recv()
+        proc.join()
+        return res
+
+    prior = pyabc.Distribution(
+        p0=pyabc.RV('uniform', -5, 10), p1=pyabc.RV('uniform', -2, 2))
+
+    def distance(y1, y2):
+        return np.abs(y1['y'] - y2['y']).sum()
+
+    obs = {'y': 1}
+    # False and None as daemon arguments are ok, True is not allowed
+    sampler = RedisEvalParallelSamplerServerStarter(
+        workers=1, processes_per_worker=2, daemon=False)
+    try:
+        abc = pyabc.ABCSMC(
+            model, prior, distance, sampler=sampler,
+            population_size=10)
+        abc.new(pyabc.create_sqlite_db_id(), obs)
+        # will just never return if model evaluation fails
+        abc.run(max_nr_populations=3)
+    finally:
+        sampler.shutdown()
+
+
 def test_redis_look_ahead():
     """Test the redis sampler in look-ahead mode."""
     model, prior, distance, obs = basic_testcase()


### PR DESCRIPTION
Fixes #373

The default (daemon=True) should not have been changed. This ensures that the subprocesses are shutdown when the main process gets killed. If daemon=False is needed, care must be taken :exclamation: 