### PR TITLE
make MultiVariateNormal.pdf work with np.ndarrays

### DIFF
--- a/pyabc/inference/util.py
+++ b/pyabc/inference/util.py
@@ -252,8 +252,8 @@ def create_transition_pdf(
         model_factor = sum(
             row.p * model_perturbation_kernel.pmf(m_ss, m)
             for m, row in model_probabilities.iterrows())
-        particle_factor = transitions[m_ss].pdf(
-            pd.Series(dict(theta_ss)))
+        x = np.array(list(dict(theta_ss).values()))
+        particle_factor = transitions[m_ss].pdf(x)
 
         transition_pd = model_factor * particle_factor
 

--- a/pyabc/transition/base.py
+++ b/pyabc/transition/base.py
@@ -88,7 +88,7 @@ class Transition(BaseEstimator, metaclass=TransitionMeta):
         return pd.DataFrame([self.rvs_single() for _ in range(size)])
 
     @abstractmethod
-    def pdf(self, x: Union[pd.Series, pd.DataFrame]) \
+    def pdf(self, x: Union[pd.Series, pd.DataFrame, np.ndarray]) \
             -> Union[float, np.ndarray]:
         """
         Evaluate the probability density function (PDF) at `x`.


### PR DESCRIPTION
In https://github.com/ICB-DCM/pyABC/issues/351#issuecomment-746588118 I brought up a possible optimization.

Using this simple trick, I sped up the `abc.run` call below by ~30%.

The code execution time varies widely from run to run, however, the amount of time spend in `_prepare_next_iteration` drops from ~50% of the total time to ~15%.

```python
import os

os.environ.update(
    {
        "MKL_NUM_THREADS": "1",
        "OPENBLAS_NUM_THREADS": "1",
        "OMP_NUM_THREADS": "1",
        "NUMEXPR_NUM_THREADS": "1",
    }
)

import numpy as np
import pyabc
import matplotlib.pyplot as plt
import uuid

slope_true = 0.1
intercept_true = 0.5
sigma_true = 0.02
x_vec = np.linspace(-1, 1, 100)
refval = {"slope": slope_true, "intercept": intercept_true, "sigma": sigma_true}


def model(params):
    slope = params["slope"]
    intercept = params["intercept"]
    return {"data": intercept + slope * x_vec}


true_vec = model(refval)["data"]
obs_vec = true_vec + sigma_true * np.random.randn(len(x_vec))
observation = {"data": obs_vec}

plt.plot(x_vec, true_vec)
plt.plot(x_vec, obs_vec)
plt.show()


pop_size = 50

prior = pyabc.Distribution(
    slope=pyabc.RV("uniform", -1, 2),
    intercept=pyabc.RV("uniform", -1, 2),
    sigma=pyabc.RV("uniform", 1e-5, 1),
)


def var(params):
    return params["sigma"] ** 2 * np.ones(len(x_vec))


acceptor = pyabc.StochasticAcceptor()
kernel = pyabc.IndependentNormalKernel(var=var)
eps = pyabc.Temperature()
sampler = pyabc.SingleCoreSampler()
sampler.show_progress = True

abc = pyabc.ABCSMC(
    model,
    prior,
    kernel,
    eps=eps,
    acceptor=acceptor,
    sampler=sampler,
    population_size=pop_size,
)
abc.new(
    pyabc.create_sqlite_db_id(file_=str(uuid.uuid1()) + ".db"),
    observation,
)

history = abc.run(max_nr_populations=10)
```
snakeviz result before:
![image](https://user-images.githubusercontent.com/6897215/102380890-c9685880-3fc8-11eb-8f37-56d2decc061a.png)


snakeviz result after (the selected pink block is of the same call stack, which reduced from 45% of the time spend to 17%):
![image](https://user-images.githubusercontent.com/6897215/102380856-be152d00-3fc8-11eb-9dbd-7ef246b05e13.png)


