### PR TITLE
Allow pickling of AMICI models

### DIFF
--- a/pyabc/model.py
+++ b/pyabc/model.py
@@ -239,7 +239,11 @@ class SimpleModel(Model):
                  sample_function: Callable[[Parameter], Any],
                  name: str = None):
         if name is None:
-            name = sample_function.__name__
+            if hasattr(sample_function, '__name__'):
+                name = sample_function.__name__
+            else:
+                # sample_function is a callable object
+                name = sample_function.__class__.__name__
         super().__init__(name)
         self.sample_function = sample_function
 

--- a/pyabc/petab/amici.py
+++ b/pyabc/petab/amici.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Sequence, Mapping
 from typing import Callable, Union, Dict
 import copy
+import tempfile
 
 import pyabc
 from .base import PetabImporter

--- a/pyabc/petab/amici.py
+++ b/pyabc/petab/amici.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Sequence, Mapping
-from typing import Callable, Union
+from typing import Callable, Union, Dict
 import copy
 
 import pyabc

--- a/pyabc/petab/amici.py
+++ b/pyabc/petab/amici.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Sequence, Mapping
 from typing import Callable, Union, Dict
 import copy
+import os
 import tempfile
 
 import pyabc


### PR DESCRIPTION
This PR aims to make pyABC models created from PEtab/AMICI to be pickable, enabling distributing the computation across nodes.

This follows closely the implementation in pyPESTO. If the user makes modifications to the model object or provides a model object obtained from a different PEtab problem, then the pickling will not work. But I guess this is not very probable.

We could make the `PEtabImporter` only accept a petab problem as an argument solving this problem. The user could still set solver options by accessing the returned model object.

In order for the workers to reuse the AMICI module compiled by the master process I had to make a small change in AMICI https://github.com/AMICI-dev/AMICI/pull/1383