### PR TITLE
Improve PEtab support

### DIFF
--- a/pyabc/petab/base.py
+++ b/pyabc/petab/base.py
@@ -1,116 +1,57 @@
-import pyabc
-
 from collections.abc import Sequence, Mapping
 from typing import Callable, Union
 import abc
 import logging
+import numpy as np
+import pandas as pd
+
+import pyabc
 
 logger = logging.getLogger(__name__)
 
 try:
     import petab
 except ImportError:
-
+    petab = None
     logger.error("Install petab (see https://github.com/icb-dcm/petab) to use "
                  "the petab functionality.")
 
 
 class PetabImporter(abc.ABC):
-    """
-    Import a PEtab model to parameterize it using pyABC.
+    """Import a PEtab model to parameterize it using pyABC.
 
     This class provides methods to generate prior, model, and stochastic kernel
     for a pyABC analysis.
 
     Parameters
     ----------
-
     petab_problem:
         A PEtab problem containing all information on the parameter estimation
         problem.
-    free_parameters:
-        Whether to estimate free parameters (column ESTIMATE=1 in the
-        parameters table).
-    fixed_parameters:
-        Whether to estimate fixed parameters (column ESTIMATE=0 in the
-        parameters table).
     """
 
     def __init__(
             self,
-            petab_problem: petab.Problem,
-            free_parameters: bool = True,
-            fixed_parameters: bool = False):
+            petab_problem: petab.Problem):
         self.petab_problem = petab_problem
-        self.free_parameters = free_parameters
-        self.fixed_parameters = fixed_parameters
 
     def create_prior(self) -> pyabc.Distribution:
-        """
-        Create prior.
+        """Create prior.
 
         Returns
         -------
         prior:
             A valid pyabc.Distribution for the parameters to estimate.
         """
-        # add default values
-        parameter_df = petab.normalize_parameter_df(
-            self.petab_problem.parameter_df)
-
-        prior_dct = {}
-
-        # iterate over parameters
-        for _, row in parameter_df.reset_index().iterrows():
-            # check whether we can ignore
-            if not self.fixed_parameters and row[petab.C.ESTIMATE] == 0:
-                # ignore fixed parameters
-                continue
-            if not self.free_parameters and row[petab.C.ESTIMATE] == 1:
-                # ignore free parameters
-                continue
-
-            # pyabc currently only knows objective priors, no
-            #  initialization priors
-            prior_type = row[petab.C.OBJECTIVE_PRIOR_TYPE]
-            pars_str = row[petab.C.OBJECTIVE_PRIOR_PARAMETERS]
-            prior_pars = tuple(float(val) for val in pars_str.split(';'))
-
-            # create random variable from table entry
-            if prior_type in [petab.C.PARAMETER_SCALE_UNIFORM,
-                              petab.C.UNIFORM]:
-                lb, ub = prior_pars
-                rv = pyabc.RV('uniform', lb, ub-lb)
-            elif prior_type in [petab.C.PARAMETER_SCALE_NORMAL,
-                                petab.C.NORMAL]:
-                mean, std = prior_pars
-                rv = pyabc.RV('norm', mean, std)
-            elif prior_type in [petab.C.PARAMETER_SCALE_LAPLACE,
-                                petab.C.LAPLACE]:
-                mean, scale = prior_pars
-                rv = pyabc.RV('laplace', mean, scale)
-            elif prior_type == petab.C.LOG_NORMAL:
-                mean, std = prior_pars
-                rv = pyabc.RV('lognorm', mean, std)
-            elif prior_type == petab.C.LOG_LAPLACE:
-                mean, scale = prior_pars
-                rv = pyabc.RV('loglaplace', mean, scale)
-            else:
-                raise ValueError(f"Cannot handle prior type {prior_type}.")
-
-            prior_dct[row[petab.C.PARAMETER_ID]] = rv
-
-        # create prior distribution
-        prior = pyabc.Distribution(**prior_dct)
-
-        return prior
+        return create_prior(parameter_df=self.petab_problem.parameter_df)
 
     @abc.abstractmethod
     def create_model(
         self,
     ) -> Callable[[Union[Sequence, Mapping]], Mapping]:
-        """
-        Create model. The model takes parameters and simulates data
+        """Create model.
+
+        The model takes parameters and simulates data
         for these. Different model simulation formalisms may be employed.
 
         .. note::
@@ -140,3 +81,76 @@ class PetabImporter(abc.ABC):
         kernel:
             A pyabc distribution encoding the kernel function.
         """
+
+
+def create_prior(parameter_df: pd.DataFrame) -> pyabc.Distribution:
+    """Create prior.
+
+    Note: For sampling the `PARAMETER_SCALE` is irrelevant, as the distribution
+    is fully specified via
+    `OBJECTIVE_PRIOR_TYPE` and `OBJECTIVE_PRIOR_PARAMETERS`.
+
+    Parameters
+    ----------
+    parameter_df:
+        The PEtab parameter dataframe.
+
+    Returns
+    -------
+    prior:
+        A valid pyabc.Distribution for the parameters to estimate.
+    """
+    # add default values
+    parameter_df = petab.normalize_parameter_df(parameter_df)
+
+    prior_dct = {}
+
+    # iterate over parameters
+    for _, row in parameter_df.reset_index().iterrows():
+        if row[petab.C.ESTIMATE] == 0:
+            # ignore fixed parameters
+            continue
+
+        # pyabc currently only knows objective priors, no
+        #  initialization priors
+        prior_type = row[petab.C.OBJECTIVE_PRIOR_TYPE]
+        pars_str = row[petab.C.OBJECTIVE_PRIOR_PARAMETERS]
+        prior_pars = tuple(float(val) for val in pars_str.split(';'))
+
+        # create random variable from table entry
+        if prior_type in [petab.C.PARAMETER_SCALE_UNIFORM,
+                          petab.C.UNIFORM]:
+            lb, ub = prior_pars
+            # scipy pars are location, width
+            rv = pyabc.RV('uniform', loc=lb, scale=ub-lb)
+        elif prior_type in [petab.C.PARAMETER_SCALE_NORMAL,
+                            petab.C.NORMAL]:
+            mean, std = prior_pars
+            # scipy pars are mean, std
+            rv = pyabc.RV('norm', loc=mean, scale=std)
+        elif prior_type in [petab.C.PARAMETER_SCALE_LAPLACE,
+                            petab.C.LAPLACE]:
+            mean, b = prior_pars
+            # scipy pars are loc=mean, scale=b
+            rv = pyabc.RV('laplace', loc=mean, scale=b)
+        elif prior_type == petab.C.LOG_NORMAL:
+            mean, std = prior_pars
+            # petab pars are mean, std of the underlying normal distribution
+            # scipy pars are s, loc, scale where s = std, scale = exp(mean)
+            #  as a simple calculation shows
+            rv = pyabc.RV('lognorm', s=std, loc=0, scale=np.exp(mean))
+        elif prior_type == petab.C.LOG_LAPLACE:
+            mean, b = prior_pars
+            # petab pars are mean, b of the underlying laplace distribution
+            # scipy pars are c, loc, scale where c = 1 / b, scale = exp(mean)
+            #  as a simple calculation shows
+            rv = pyabc.RV('loglaplace', c=1/b, scale=np.exp(mean))
+        else:
+            raise ValueError(f"Cannot handle prior type {prior_type}.")
+
+        prior_dct[row[petab.C.PARAMETER_ID]] = rv
+
+    # create prior distribution
+    prior = pyabc.Distribution(**prior_dct)
+
+    return prior

--- a/pyabc/random_variables.py
+++ b/pyabc/random_variables.py
@@ -14,8 +14,7 @@ rv_logger = logging.getLogger("RV")
 
 
 class RVBase(ABC):
-    """
-    Random variable abstract base class.
+    """Random variable abstract base class.
 
     .. note::
 
@@ -34,8 +33,7 @@ class RVBase(ABC):
 
     @abstractmethod
     def copy(self) -> "RVBase":
-        """
-        Copy the random variable.
+        """Copy the random variable.
 
         Returns
         -------
@@ -45,38 +43,32 @@ class RVBase(ABC):
 
     @abstractmethod
     def rvs(self, *args, **kwargs) -> float:
-        """
-        Sample from the RV.
+        """Sample from the RV.
 
         Returns
         -------
-
         sample: float
             A sample from the random variable.
         """
 
     @abstractmethod
     def pmf(self, x, *args, **kwargs) -> float:
-        """
-        Probability mass function
+        """Probability mass function.
 
         Parameters
         ----------
-
         x: int
             Probability mass at ``x``.
 
         Returns
         -------
-
         mass: float
             The mass at ``x``.
         """
 
     @abstractmethod
     def pdf(self, x: float, *args, **kwargs) -> float:
-        """
-        Probability density function
+        """Probability density function.
 
         Parameters
         ----------
@@ -85,15 +77,13 @@ class RVBase(ABC):
 
         Returns
         -------
-
         density: float
             Probability density at x.
         """
 
     @abstractmethod
     def cdf(self, x: float, *args, **kwargs) -> float:
-        """
-        Cumulative distribution function.
+        """Cumulative distribution function.
 
         Parameters
         ----------
@@ -102,26 +92,21 @@ class RVBase(ABC):
 
         Returns
         -------
-
         density: float
             Cumulative distribution function at x.
         """
 
 
 class RV(RVBase):
-    """
-    Concrete random variable.
+    """Concrete random variable.
 
     Parameters
     ----------
-
     name: str
         Name of the distribution as in ``scipy.stats``
-
     args:
         Arguments as in ``scipy.stats`` matching the distribution
         with name "name".
-
     kwargs:
         Keyword arguments as in ``scipy.stats``
         matching the distribution with name "name".
@@ -129,12 +114,10 @@ class RV(RVBase):
 
     @classmethod
     def from_dictionary(cls, dictionary: dict) -> "RV":
-        """
-        Construct random variable from dictionary.
+        """Construct random variable from dictionary.
 
         Parameters
         ----------
-
         dictionary: dict
             A dictionary with the keys
 
@@ -143,8 +126,6 @@ class RV(RVBase):
                * "kwargs" (optional)
 
             as in scipy.stats.
-
-
 
         .. note::
 
@@ -197,8 +178,7 @@ class RV(RVBase):
 
 
 class RVDecorator(RVBase):
-    """
-    Random variable decorater base class.
+    """Random variable decorator base class.
 
     Implement a decorator pattern.
 
@@ -212,7 +192,6 @@ class RVDecorator(RVBase):
 
     Parameters
     ----------
-
     component: RVBase
         The random variable to be decorated.
     """
@@ -236,8 +215,7 @@ class RVDecorator(RVBase):
         return self.__class__(self.component.copy())
 
     def decorator_repr(self) -> str:  # pylint: disable=R0201
-        """
-        Represent the decorator itself.
+        """Represent the decorator itself.
 
         Template method.
 
@@ -247,7 +225,6 @@ class RVDecorator(RVBase):
 
         Returns
         -------
-
         decorator_repr: str
             A string representing the decorator only.
         """
@@ -275,10 +252,8 @@ class LowerBoundDecorator(RVDecorator):
 
     Parameters
     ----------
-
     component: RV
         The decorated random variable.
-
     lower_bound: float
         The lower bound.
     """
@@ -326,8 +301,7 @@ class LowerBoundDecorator(RVDecorator):
 
 
 class Distribution(ParameterStructure):
-    """
-    Distribution of parameters for a model.
+    """Distribution of parameters for a model.
 
     A distribution is a collection of RVs and/or distributions.
     Essentially something like a dictionary
@@ -345,8 +319,7 @@ class Distribution(ParameterStructure):
     @classmethod
     def from_dictionary_of_dictionaries(cls,
                                         dict_of_dicts: dict) -> "Distribution":
-        """
-        Create distribution from dictionary of dictionaries
+        """Create distribution from dictionary of dictionaries.
 
         Parameters
         ----------
@@ -358,7 +331,6 @@ class Distribution(ParameterStructure):
 
         Returns
         -------
-
         distribution: Distribution
             Created distribution.
         """
@@ -369,12 +341,10 @@ class Distribution(ParameterStructure):
         return cls(rv_dictionary)
 
     def copy(self) -> "Distribution":
-        """
-        Copy the distribution
+        """Copy the distribution.
 
         Returns
         -------
-
         copied_distribution: Distribution
             A copy of the distribution.
         """
@@ -383,35 +353,29 @@ class Distribution(ParameterStructure):
                                  for key, value in self.items()})
 
     def update_random_variables(self, **random_variables):
-        """
-        Update random variables within the distribution
+        """Update random variables within the distribution.
 
         Parameters
         ----------
-
         **random_variables:
             keywords are the parameters' names, the values are random variable.
-
         """
 
         self.update(random_variables)
 
     def get_parameter_names(self) -> list:
-        """
-        Sorted list of parameter names.
+        """Get a sorted list of parameter names.
 
         Returns
         -------
-
         sorted_names: list
             Sorted list of parameter names.
         """
 
         return sorted(self.keys())
 
-    def rvs(self) -> Parameter:
-        """
-        Sample from joint distribution
+    def rvs(self, *args, **kwargs) -> Parameter:
+        """Sample from joint distribution.
 
         Returns
         -------
@@ -420,13 +384,14 @@ class Distribution(ParameterStructure):
             A parameter which was sampled.
         """
 
-        return Parameter(**{key: val.rvs() for key, val in self.items()})
+        return Parameter(**{key: val.rvs(*args, **kwargs)
+                            for key, val in self.items()})
 
     def pdf(self, x: Union[Parameter, dict]):
-        """
-        Get combination of probability density function (for continuous
-        variables) and
-        probability mass function (for discrete variables) at point x
+        """Get probability density at point `x` (product of marginals).
+
+        Combination of probability density functions (for continuous
+        variables) and probability mass function (for discrete variables).
 
         Parameters
         ----------

--- a/pyabc/random_variables.py
+++ b/pyabc/random_variables.py
@@ -173,7 +173,7 @@ class RV(RVBase):
         return self.distribution.cdf(x, *args, **kwargs)
 
     def __repr__(self):
-        return ("<RV(name={name}, args={args} kwargs={kwargs})>"
+        return ("<RV name={name}, args={args}, kwargs={kwargs}>"
                 .format(name=self.name, args=self.args, kwargs=self.kwargs))
 
 
@@ -313,8 +313,8 @@ class Distribution(ParameterStructure):
     """
 
     def __repr__(self):
-        return "<Distribution {keys}>".format(
-            keys=str(list(self.get_parameter_names()))[1:-1])
+        return "<Distribution\n    " + \
+            ",\n    ".join(f"{id}={rv}" for id, rv in self.items()) + ">"
 
     @classmethod
     def from_dictionary_of_dictionaries(cls,

--- a/pyabc/sge/sge.py
+++ b/pyabc/sge/sge.py
@@ -22,7 +22,8 @@ class SGESignatureMismatchException(Exception):
 
 
 class SGE:
-    """Map a function to be executed on an SGE cluster environment
+    """Map a function to be executed on an SGE cluster environment.
+
     Reads a config file (if it exists) in you home directory
     which should look as the default
     in sge.config.
@@ -30,7 +31,6 @@ class SGE:
     The mapper reads commonly used parameters from a configuration file
     stored in ``~/.parallel``
     An example configuration file could look as follows:
-
 
     .. code-block:: bash
 
@@ -50,56 +50,43 @@ class SGE:
         [REDIS]
         HOST=127.0.0.1
 
-
     Parameters
     ----------
-
     tmp_directory: str or None
         Directory where temporary job pickle files are stored
         If set to None a tmp directory is read from the ''~/.parallel''
         configuration file.
         It this file does not exist a tmp directory within the user home
         directory is created.
-
     memory: str, optional (default = '3G')
         Ram requested by each job, e.g. '10G'.
-
     time_h: int (default = 100)
         Job run time in hours.
-
     python_executable_path: str or None
         The python interpreter which executes the jobs.
         If set to None, the currently executing interpreter is used as
         returned by ``sys.executable``.
-
     sge_error_file: str or None
         File to which stderr messages from workers are stored.
         If set to None, a file within the tmp_directory is used.
-
     sge_output_file: str or None
         File to which stdout messages from workers are stored
         If set to None, a file within the tmp_directory is used.
-
     parallel_environment: str, optional (default = 'map')
         The SGE environment. (This is what is passed to the -pe option
         in the qsub script).
-
     name: str
         A name for the job.
-
     queue: str
         The SGE queue.
-
     priority: int, optional.
         SGE job priority. A value between -1000 and 0.
         Note that a priority of 0 automatically enables the reservation flag.
-
     num_threads: int, optional (default = 1)
         Number of threads for each worker.
         This also sets the environment variable MKL_NUM_THREADS,
         OMP_NUM_THREADS to the
         specified number to handle jobs which use OpenMP etc. correctly.
-
     execution_context: \
     :class:`DefaultContext \
         <pyabc.sge.execution_contexts.DefaultContext>`,\
@@ -112,7 +99,6 @@ class SGE:
         The ``__enter__`` method is called before evaluating the function on
         the cluster.
         The ``__exit__`` method directly after the function run finished.
-
     chunk_size: int, optional (default = 1)
         nr of tasks executed within one job.
 
@@ -122,7 +108,6 @@ class SGE:
                 side effects
                 as all the jobs within one chunk are executed within the python
                 process.
-
 
     Returns
     -------
@@ -198,12 +183,12 @@ class SGE:
                 self.config["DIRECTORIES"]["TMP"], "sge_output.txt")
 
     def __repr__(self):
-        return ("<SGE memory={} time={} priority={} num_threads={} "
-                "chunk_size={} tmp_dir={} python_executable={}>"
-                .format(self.memory, self.time, self.config["SGE"]["PRIORITY"],
-                        self.num_threads, self.chunk_size,
-                        self.config["DIRECTORIES"]["TMP"],
-                        self.python_executable_path))
+        return (f"<SGE memory={self.memory}, time={self.time}, "
+                f"priority={self.config['SGE']['PRIORITY']}, "
+                f"num_threads={self.num_threads}, "
+                f"chunk_size={self.chunk_size}, "
+                f"tmp_dir={self.config['DIRECTORIES']['TMP']}, "
+                f"python_executable={self.python_executable_path}>")
 
     @staticmethod
     def _validate_function_arguments(function, array):

--- a/pyabc/storage/db_model.py
+++ b/pyabc/storage/db_model.py
@@ -45,18 +45,16 @@ class ABCSMC(Base):
     populations = relationship("Population")
 
     def __repr__(self):
-        return ("<ABCSMC(id={id}, start_time={start_time}, "
-                "end_time={end_time})>"
-                .format(id=self.id, start_time=self.start_time,
-                        end_time=self.end_time))
+        return (f"<ABCSMC id={self.id}, start_time={self.start_time}, "
+                "end_time={self.end_time}>")
 
     def start_info(self):
-        return f"<ABCSMC(id={self.id}, start_time={self.start_time})>"
+        return f"<ABCSMC id={self.id}, start_time={self.start_time}>"
 
     def end_info(self):
         duration = self.end_time - self.start_time
-        return f"<ABCSMC(id={self.id}, duration={duration}, " \
-               f"end_time={self.end_time}>"
+        return (f"<ABCSMC id={self.id}, duration={duration}, "
+                f"end_time={self.end_time}>")
 
 
 class Population(Base):
@@ -74,13 +72,10 @@ class Population(Base):
         self.population_end_time = datetime.datetime.now()
 
     def __repr__(self):
-        return ("<Population(id={id}, abc_smc_id={abc_smc_id}, t={t}) "
-                "nr_samples={nr_samples} eps={eps} "
-                "population_end_time={population_end_time}>"
-                .format(id=self.id, abc_smc_id=self.abc_smc_id, t=self.t,
-                        nr_samples=self.nr_samples,
-                        eps=self.epsilon,
-                        population_end_time=self.population_end_time))
+        return (f"<Population id={self.id}, abc_smc_id={self.abc_smc_id}, "
+                f"t={self.t}, nr_samples={self.nr_samples}, "
+                f"eps={self.epsilon}, "
+                f"population_end_time={self.population_end_time}>")
 
 
 class Model(Base):
@@ -93,9 +88,8 @@ class Model(Base):
     particles = relationship("Particle")
 
     def __repr__(self):
-        return ("<Model id={} population_id={} m ={} name={} p_model={}>"
-                .format(self.id, self.population_id, self.m, self.name,
-                        self.p_model))
+        return (f"<Model id={self.id}, population_id={self.population_id}, "
+                f"m={self.m}, name={self.name}, p_model={self.p_model}>")
 
 
 class Particle(Base):
@@ -115,8 +109,7 @@ class Parameter(Base):
     value = Column(Float)
 
     def __repr__(self):
-        return "<{} {}={}>".format(self.__class__.__name__,
-                                   self.name, self.value)
+        return f"<Particle {self.name}={self.value}>"
 
 
 class Sample(Base):

--- a/test/external/test_external.py
+++ b/test/external/test_external.py
@@ -86,7 +86,7 @@ def test_external():
         executable, folder + "distance.r")
 
     # call representation function
-    model.__repr__()
+    print(model.__repr__())
 
     # create a dummy observed sum stat
     dummy_sum_stat = pyabc.external.create_sum_stat()

--- a/test/petab/test_petab.py
+++ b/test/petab/test_petab.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import numpy as np
 import scipy.stats
@@ -183,12 +184,16 @@ def test_pipeline():
         pass
 
     # create problem
+    model_name = 'Boehm_JProteomeRes2014'
     petab_problem = petab.Problem.from_yaml(os.path.join(
-        benchmark_dir, "Benchmark-Models",
-        "Boehm_JProteomeRes2014", "Boehm_JProteomeRes2014.yaml"))
+        benchmark_dir, 'Benchmark-Models', model_name, model_name + '.yaml'))
 
     # compile amici
-    model = amici.petab_import.import_petab_problem(petab_problem)
+    output_folder = f'amici_models/{model_name}'
+    if output_folder not in sys.path:
+        sys.path.insert(0, output_folder)
+    model = amici.petab_import.import_petab_problem(
+        petab_problem, model_output_dir=output_folder)
     solver = model.getSolver()
 
     # import to pyabc
@@ -201,7 +206,7 @@ def test_pipeline():
 
     # call model
     assert np.isclose(
-        model(petab_problem.x_nominal_free_scaled)['llh'], -138.221996)
+        model(importer.get_nominal_parameters())['llh'], -138.221996)
 
     # mini analysis, just to run it
     temperature = pyabc.Temperature(

--- a/test/petab/test_petab.py
+++ b/test/petab/test_petab.py
@@ -1,13 +1,113 @@
-import amici.petab_import
-import petab
-import pyabc.petab
-
-import git
 import os
 import numpy as np
+import pandas as pd
+import pytest
+import git
+import itertools
+
+import amici.petab_import
+import petab
+import petab.C as C
+import pyabc.petab
+import pyabc.petab.base
 
 
-def test_import():
+@pytest.fixture(params=itertools.product(
+    [petab.C.LIN, petab.C.LOG, petab.C.LOG10],
+    petab.C.PRIOR_TYPES))
+def prior_specs(request):
+    """A one-line parameter df for a given prior type."""
+    scale, prior_type = request.param
+    var1, var2 = 0.2, 0.9
+    df = pd.DataFrame({
+        C.PARAMETER_ID: ['p1'],
+        C.ESTIMATE: [1],
+        C.PARAMETER_SCALE: [scale],
+        C.LOWER_BOUND: [np.nan],
+        C.UPPER_BOUND: [np.nan],
+        C.OBJECTIVE_PRIOR_TYPE: [prior_type],
+        C.OBJECTIVE_PRIOR_PARAMETERS: [f"{var1};{var2}"],
+    })
+    return scale, prior_type, var1, var2, df
+
+
+def test_petab_prior(prior_specs):
+    """Test whether the prior is correctly defined by sampling from it."""
+    # extract settings
+    scale, prior_type, var1, var2, parameter_df = prior_specs
+
+    # create prior from petab data frame
+    pyabc_prior = pyabc.petab.base.create_prior(parameter_df)
+
+    # generate random samples
+    n_samples = 10000
+    samples = pyabc_prior.rvs(size=n_samples)['p1']
+
+    # check that uniform parameters fill their domain
+    if prior_type in [C.UNIFORM, C.PARAMETER_SCALE_UNIFORM]:
+        assert (samples >= var1).all() and (samples <= var2).all()
+        assert ((samples >= var2 - (var2-var1)*0.01).any() and
+                (samples <= var1 + (var2-var1)*0.01).any())
+
+    # sample mean and variance
+    mean = np.mean(samples)
+    var = np.var(samples)
+
+    # ground truth mean and variance
+    if prior_type in [C.UNIFORM, C.PARAMETER_SCALE_UNIFORM]:
+        mean_th = var1 + (var2 - var1) / 2
+        var_th = (var2 - var1)**2 / 12
+    elif prior_type in [C.NORMAL, C.PARAMETER_SCALE_NORMAL]:
+        mean_th = var1
+        var_th = var2**2
+    elif prior_type in [C.LAPLACE, C.PARAMETER_SCALE_LAPLACE]:
+        mean_th = var1
+        var_th = 2 * var2**2
+    elif prior_type == C.LOG_NORMAL:
+        # just log-transform all
+        mean = np.mean(np.log(samples))
+        var = np.var(np.log(samples))
+        mean_th = var1
+        var_th = var2**2
+    elif prior_type == C.LOG_LAPLACE:
+        # just log-transform all
+        mean = np.mean(np.log(samples))
+        var = np.var(np.log(samples))
+        mean_th = var1
+        var_th = 2 * var2**2
+    else:
+        raise ValueError(f"Unexpected prior type: {prior_type}")
+
+    # multiplicative tolerance of sample vs ground truth variables
+    tol = 0.8
+    assert mean_th * tol < mean < mean_th * 1 / tol
+    assert var_th * tol < var < var_th * 1 / tol
+
+
+def test_parameter_fixing():
+    """Test that only free parameters are exposed to pyABC."""
+    # define problem with fixed parameters
+    parameter_df = pd.DataFrame({
+        C.PARAMETER_ID: ['p1', 'p2', 'p3'],
+        C.ESTIMATE: [1, 0, 1],
+        C.PARAMETER_SCALE: [C.LIN] * 3,
+        C.LOWER_BOUND: [0] * 3,
+        C.UPPER_BOUND: [1] * 3,
+        C.OBJECTIVE_PRIOR_TYPE: [C.PARAMETER_SCALE_UNIFORM] * 3,
+    })
+
+    # create prior from petab data frame
+    pyabc_prior = pyabc.petab.base.create_prior(parameter_df)
+
+    # create a sample
+    sample = pyabc_prior.rvs()
+
+    # check the entries
+    assert set(sample.keys()) == {'p1', 'p3'}
+
+
+def test_pipeline():
+    """Test the petab pipeline on an application model."""
     # download archive
     benchmark_dir = "doc/examples/tmp/benchmark-models-petab"
     if not os.path.exists(benchmark_dir):
@@ -44,7 +144,7 @@ def test_import():
     assert np.isclose(
         model(petab_problem.x_nominal_free_scaled)['llh'], -138.221996)
 
-    # mini analysis
+    # mini analysis, just to run it
     temperature = pyabc.Temperature(
         enforce_exact_final_temperature=False,
         schemes=[pyabc.AcceptanceRateScheme()])

--- a/test/petab/test_petab_suite.py
+++ b/test/petab/test_petab_suite.py
@@ -3,7 +3,9 @@
 import petabtests
 import pyabc
 
+
 import os
+import sys
 import pytest
 from _pytest.outcomes import Skipped
 import logging
@@ -80,6 +82,8 @@ def _execute_case(case):
     petab_problem = petab.Problem.from_yaml(yaml_file)
 
     # compile amici
+    if output_folder not in sys.path:
+        sys.path.insert(0, output_folder)
     amici_model = amici.petab_import.import_petab_problem(
         petab_problem=petab_problem,
         model_output_dir=output_folder)
@@ -91,7 +95,7 @@ def _execute_case(case):
     model = importer.create_model(return_rdatas=True)
 
     # simulate
-    problem_parameters = petab_problem.x_nominal_free_scaled
+    problem_parameters = importer.get_nominal_parameters()
     ret = model(problem_parameters)
 
     llh = ret['llh']


### PR DESCRIPTION
* Fix wrong import of log distributions (wrong arguments, wrong scale before). Principle: Prior returns parameters on prior scale, therefore model has to rescale inputs.
* Add tests for prior generation
* Discard that overly complicated allowing to estimate fixed parameters too
* Now, pyABC should support all priors defined in PEtab.
* Note: Currently sampling is always performed on prior scale, which should be statistically correct , but ignores the PEtab idea of defining a separate parameter scale. How that is to be interpreted in terms of transformation is yet TBD. 