### PR TITLE
Fix PEtab test suite

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -71,6 +71,7 @@ intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/dev', None),
     'petab': ('https://petab.readthedocs.io/en/stable/', None),
     'amici': ('https://amici.readthedocs.io/en/latest/', None),
+    "sklearn": ("https://scikit-learn.org/stable/", None),
 }
 
 

--- a/pyabc/transition/local_transition.py
+++ b/pyabc/transition/local_transition.py
@@ -84,8 +84,8 @@ class LocalTransition(Transition):
             raise NotEnoughParticles("Fitting not possible.")
         self.X_arr = X.values
 
-        ctree = cKDTree(X)
-        _, indices = ctree.query(X, k=min(self.k + 1, X.shape[0]))
+        ctree = cKDTree(self.X_arr)
+        _, indices = ctree.query(self.X_arr, k=min(self.k + 1, X.shape[0]))
 
         covs, inv_covs, dets = list(
             zip(*[self._cov_and_inv(n, indices) for n in range(X.shape[0])])


### PR DESCRIPTION
PEtab test suite started failing after moving from amici==0.17.1 -> amici==0.18.0, due to importing different models with the same name. Fixed by using distinct names.

Adapt to `petabtests` API changes.

Fixes #607