### PR TITLE
Fix minor bug in petab importer

### DIFF
--- a/pyabc/petab/amici.py
+++ b/pyabc/petab/amici.py
@@ -82,8 +82,8 @@ class AmiciModel:
         for key in self.prior_scales.keys():
             par[key] = rescale(
                 val=par[key],
-                origin_scale=self.prior_scales,
-                target_scale=self.scaled_scales,
+                origin_scale=self.prior_scales[key],
+                target_scale=self.scaled_scales[key],
             )
 
         # simulate model


### PR DESCRIPTION
The Petab importer also generates an Amici model, which requires adapting parameter scales. However, a small bug occurred due to passing the entire dictionary to the rescale function instead of just the specific dictionary value. This resulted in failure during simulation. 