### PR TITLE
Fix external distance function

### DIFF
--- a/pyabc/external/r/r_rpy2.py
+++ b/pyabc/external/r/r_rpy2.py
@@ -162,7 +162,7 @@ class R:
 
             res = np.asarray(distance(*args)).squeeze()
             if res.size != 1:
-                raise TypeError(
+                raise ValueError(
                     f"R distance function '{function_name}' must return a single "
                     f"numeric value, but got shape {res.shape} (size={res.size})."
                 )


### PR DESCRIPTION
This pull request improves the robustness of the `distance` method in `pyabc/external/r/r_rpy2.py` by adding stricter validation of the output from the R distance function. Now, the code checks that the result is a single numeric value and raises an informative error if it is not.