### PR TITLE
FIX broken docstring for ExpDecayFixedIterScheme

### DIFF
--- a/pyabc/epsilon/temperature.py
+++ b/pyabc/epsilon/temperature.py
@@ -434,7 +434,6 @@ class ExpDecayFixedIterScheme(TemperatureScheme):
 
     Parameters
     ----------
-
     alpha: float
         Factor by which to reduce the temperature, if `max_nr_populations`
         is infinite.


### PR DESCRIPTION
The docstring containted one empty line to many, so the parameter was not shown in the docs.